### PR TITLE
Migration to php 8.1

### DIFF
--- a/live-widget-luftdaten.php
+++ b/live-widget-luftdaten.php
@@ -3,7 +3,7 @@
 Plugin Name: Live Widget Luftdaten.info
 Plugin URI: http://www.bleeptrack.de/feinstaub-widget/
 Description: Plugin with widget to show live data from a luftdaten.info sensor
-Version: 1.3.1
+Version: 1.3.2
 Author: Bleeptrack
 Author URI: http://www.bleeptrack.de/
 License: GPL2
@@ -13,8 +13,8 @@ License: GPL2
 class LuftdatenAmpel extends WP_Widget {
 
 	// constructor
-	function LuftdatenAmpel() {
-		parent::WP_Widget(false, $name = __('Luftdaten Ampel', 'LuftdatenAmpel') );
+	function __construct() {
+		parent::__construct(false, $name = __('Luftdaten Ampel', 'LuftdatenAmpel') );
 	}
 
 	// widget form creation
@@ -307,8 +307,8 @@ class LuftdatenAmpel extends WP_Widget {
 class LuftdatenWidget extends WP_Widget {
 
 	// constructor
-	function LuftdatenWidget() {
-		parent::WP_Widget(false, $name = __('Luftdaten Live Widget', 'LuftdatenWidget') );
+	function __construct() {
+		parent::__construct(false, $name = __('Luftdaten Live Widget', 'LuftdatenWidget') );
 	}
 
 	// widget form creation
@@ -524,10 +524,14 @@ class Sensor{
 	}
 }
 
-// register widget
-add_action('widgets_init', create_function('', 'return register_widget("LuftdatenWidget");'));
-add_action('widgets_init', create_function('', 'return register_widget("LuftdatenAmpel");'));
 
+// register widget
+function lda_register_widgets() {
+	register_widget("LuftdatenAmpel");
+	register_widget("LuftdatenWidget");
+}
+
+add_action('widgets_init', 'lda_register_widgets');
 
 ///shortcodes
 
@@ -583,7 +587,6 @@ function feinstaubampel($atts) {
     $attr = array(
     	'title' => $title,
     	);
-
 
     if(isset($atts['sensorids'])){
     	$comma_separated = explode(",", $atts['sensorids'] );


### PR DESCRIPTION
When I updated the server PHP version to 8.1 WordPress showed an error screen in front- and back-end when loading the plugin. create_function was removed due to security reasons in the meantime. 
  https://www.php.net/manual/en/function.create-function

The constructors now need to be defined using __construct. 
  https://www.php.net/manual/en/language.oop5.decon.php

FYI I have used the code from within the current version of the WordPress plugin. That's why the version is 1.3.2 now it seems.

@bleeptrack Can you please redeploy the code to the plugin repository afterwards?

Thanks for the plugin!

BTW I have not yet tested the other features such as the map, but if I find something more to do I will create a separate pull request.